### PR TITLE
KAN-67 Check update catalogs issue

### DIFF
--- a/app/src/main/java/com/ih/osm/data/repository/cards/CardRepositoryImpl.kt
+++ b/app/src/main/java/com/ih/osm/data/repository/cards/CardRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.ih.osm.data.repository.cards
 
+import android.util.Log
 import com.ih.osm.data.database.dao.card.CardDao
 import com.ih.osm.data.database.entities.card.toDomain
 import com.ih.osm.data.model.CreateCardRequest
@@ -31,10 +32,13 @@ class CardRepositoryImpl
         }
 
         override suspend fun getAll(): List<Card> {
-            return dao.getAll().map {
-                val hasLocalSolutions = solutionRepo.getAllByCard(it.uuid)
-                it.toDomain(hasLocalSolutions = hasLocalSolutions.isNotEmpty())
-            }.sortedByDescending { it.id }
+            val cards =
+                dao.getAll().map {
+                    val hasLocalSolutions = solutionRepo.getAllByCard(it.uuid)
+                    it.toDomain(hasLocalSolutions = hasLocalSolutions.isNotEmpty())
+                }.sortedBy { it.id }
+            Log.e("CardRepository", "Orden de subida: ${cards.map { it.id }}")
+            return cards
         }
 
         override suspend fun getLastCardId(): String? {
@@ -57,15 +61,18 @@ class CardRepositoryImpl
                     localCards.add(card)
                 }
             }
-            return localCards.toSet().map { cardEntity ->
-                val evidences =
-                    evidenceRepo.getAllByCard(cardEntity.uuid)
-                val hasLocalSolutions = solutionRepo.getAllByCard(cardEntity.uuid)
-                cardEntity.toDomain(
-                    evidences = evidences,
-                    hasLocalSolutions = hasLocalSolutions.isNotEmpty(),
-                )
-            }.sortedByDescending { it.siteCardId }
+            val sortedCards =
+                localCards.toSet().map { cardEntity ->
+                    val evidences =
+                        evidenceRepo.getAllByCard(cardEntity.uuid)
+                    val hasLocalSolutions = solutionRepo.getAllByCard(cardEntity.uuid)
+                    cardEntity.toDomain(
+                        evidences = evidences,
+                        hasLocalSolutions = hasLocalSolutions.isNotEmpty(),
+                    )
+                }.sortedBy { it.siteCardId }
+            Log.e("CardRepository", "Orden de subida local: ${sortedCards.map { it.siteCardId }}")
+            return sortedCards
         }
 
         override suspend fun delete(uuid: String) {

--- a/app/src/main/java/com/ih/osm/data/repository/cards/CardRepositoryImpl.kt
+++ b/app/src/main/java/com/ih/osm/data/repository/cards/CardRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.ih.osm.data.repository.cards
 
-import android.util.Log
 import com.ih.osm.data.database.dao.card.CardDao
 import com.ih.osm.data.database.entities.card.toDomain
 import com.ih.osm.data.model.CreateCardRequest
@@ -37,7 +36,6 @@ class CardRepositoryImpl
                     val hasLocalSolutions = solutionRepo.getAllByCard(it.uuid)
                     it.toDomain(hasLocalSolutions = hasLocalSolutions.isNotEmpty())
                 }.sortedBy { it.id }
-            Log.e("CardRepository", "Orden de subida: ${cards.map { it.id }}")
             return cards
         }
 
@@ -71,7 +69,6 @@ class CardRepositoryImpl
                         hasLocalSolutions = hasLocalSolutions.isNotEmpty(),
                     )
                 }.sortedBy { it.siteCardId }
-            Log.e("CardRepository", "Orden de subida local: ${sortedCards.map { it.siteCardId }}")
             return sortedCards
         }
 

--- a/app/src/main/java/com/ih/osm/ui/pages/account/AccountScreen.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/account/AccountScreen.kt
@@ -9,7 +9,14 @@ import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ExitToApp
@@ -21,22 +28,25 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.ExitToApp
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -161,26 +171,41 @@ fun AccountContent(
                 )
 
                 ListItem(
-                    headlineContent = { Text(text = stringResource(R.string.use_data_mobile)) },
+                    headlineContent = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.use_data_mobile), modifier = Modifier.weight(1f))
+                            Button(
+                                onClick = { onAction(AccountAction.SetSwitch(true)) },
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = if (checked) Color.Green else Color.Gray,
+                                    ),
+                                modifier = Modifier.height(30.dp),
+                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                            ) {
+                                Text("SI", style = MaterialTheme.typography.bodySmall)
+                            }
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Button(
+                                onClick = { onAction(AccountAction.SetSwitch(false)) },
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = if (!checked) Color.Red else Color.Gray,
+                                    ),
+                                modifier = Modifier.height(30.dp),
+                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                            ) {
+                                Text("NO", style = MaterialTheme.typography.bodySmall)
+                            }
+                        }
+                    },
                     leadingContent = {
                         Icon(
                             painterResource(id = R.drawable.ic_wifi),
                             contentDescription = stringResource(R.string.empty),
-                        )
-                    },
-                    trailingContent = {
-                        Switch(
-                            checked = checked,
-                            onCheckedChange = {
-                                onAction(AccountAction.SetSwitch(it))
-                            },
-                            colors =
-                                SwitchDefaults.colors(
-                                    checkedThumbColor = MaterialTheme.colorScheme.primary,
-                                    checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
-                                    uncheckedThumbColor = MaterialTheme.colorScheme.secondary,
-                                    uncheckedTrackColor = MaterialTheme.colorScheme.secondaryContainer,
-                                ),
                         )
                     },
                     tonalElevation = PaddingNormal,

--- a/app/src/main/java/com/ih/osm/ui/pages/account/AccountScreen.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/account/AccountScreen.kt
@@ -41,12 +41,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -181,22 +181,40 @@ fun AccountContent(
                                 onClick = { onAction(AccountAction.SetSwitch(true)) },
                                 colors =
                                     ButtonDefaults.buttonColors(
-                                        containerColor = if (checked) Color.Green else Color.Gray,
+                                        containerColor =
+                                            if (checked) {
+                                                colorResource(id = R.color.button_green)
+                                            } else {
+                                                colorResource(id = R.color.button_gray)
+                                            },
                                     ),
-                                modifier = Modifier.height(30.dp),
-                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                                modifier = Modifier.height(dimensionResource(id = R.dimen.button_height)),
+                                contentPadding =
+                                    PaddingValues(
+                                        horizontal = dimensionResource(id = R.dimen.button_padding_horizontal),
+                                        vertical = dimensionResource(id = R.dimen.button_padding_vertical),
+                                    ),
                             ) {
-                                Text("SI", style = MaterialTheme.typography.bodySmall)
+                                Text("YES", style = MaterialTheme.typography.bodySmall)
                             }
-                            Spacer(modifier = Modifier.width(4.dp))
+                            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.button_spacing)))
                             Button(
                                 onClick = { onAction(AccountAction.SetSwitch(false)) },
                                 colors =
                                     ButtonDefaults.buttonColors(
-                                        containerColor = if (!checked) Color.Red else Color.Gray,
+                                        containerColor =
+                                            if (!checked) {
+                                                colorResource(id = R.color.button_red)
+                                            } else {
+                                                colorResource(id = R.color.button_gray)
+                                            },
                                     ),
-                                modifier = Modifier.height(30.dp),
-                                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                                modifier = Modifier.height(dimensionResource(id = R.dimen.button_height)),
+                                contentPadding =
+                                    PaddingValues(
+                                        horizontal = dimensionResource(id = R.dimen.button_padding_horizontal),
+                                        vertical = dimensionResource(id = R.dimen.button_padding_vertical),
+                                    ),
                             ) {
                                 Text("NO", style = MaterialTheme.typography.bodySmall)
                             }

--- a/app/src/main/java/com/ih/osm/ui/pages/createcard/CreateCardViewModel.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/createcard/CreateCardViewModel.kt
@@ -86,7 +86,7 @@ class CreateCardViewModel
         fun process(action: CreateCardAction) {
             when (action) {
                 is CreateCardAction.SetCardType -> handleSetCardType(action.id)
-                is CreateCardAction.SetPreclassifier -> setState { copy(selectedPreclassifier = action.id) }
+                is CreateCardAction.SetPreclassifier -> handleSetPreclassifier(action.id)
                 is CreateCardAction.SetPriority -> handleSetPriority(action.id)
                 is CreateCardAction.SetLevel -> handleSetLevel(action.id, action.key)
                 is CreateCardAction.SetComment -> setState { copy(comment = action.comment) }
@@ -176,9 +176,15 @@ class CreateCardViewModel
                         comment = EMPTY,
                     )
                 }
-                handleGetPriorities()
                 handleGetPreclassifiers(id)
                 handleGetCardType(id)
+            }
+        }
+
+        private fun handleSetPreclassifier(id: String) {
+            viewModelScope.launch {
+                setState { copy(selectedPreclassifier = id, selectedPriority = EMPTY, priorityList = emptyList()) }
+                handleGetPriorities()
             }
         }
 

--- a/app/src/main/java/com/ih/osm/ui/pages/home/HomeScreenV2.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/home/HomeScreenV2.kt
@@ -91,6 +91,7 @@ import com.ih.osm.ui.utils.CARD_ANOMALIES
 import com.ih.osm.ui.utils.EMPTY
 import com.ih.osm.ui.utils.LOAD_CATALOGS
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 
 @SuppressLint("CoroutineCreationDuringComposition")
 @Composable
@@ -122,6 +123,7 @@ fun HomeScreenV2(
                         viewModel.process(HomeAction.SyncCatalogs(LOAD_CATALOGS))
                     }
                     HomeActionClick.LOCAL_CARDS -> {
+                        Log.e("HomeScreenV2", "Intentando sincronizar tarjetas locales...")
                         viewModel.process(HomeAction.SyncLocalCards(context))
                     }
 
@@ -162,14 +164,14 @@ fun HomeScreenV2(
 //                } else if (state.isSyncing.not()) {
 //                  //  viewModel.process(HomeViewModel.Action.GetCards)
 //                }
-//                if (state.message.isNotEmpty() && state.isLoading.not()) {
-//                    scope.launch {
-//                        snackBarHostState.showSnackbar(
-//                            message = state.message
-//                        )
+                Log.e("Snackbar", "Recibido mensaje en UI: ${state.message}")
+                if (state.message.isNotEmpty() && state.isLoading.not()) {
+                    Log.e("Snackbar", "Mostrando Snackbar con mensaje: ${state.message}")
+                    scope.launch {
+                        snackBarHostState.showSnackbar(message = state.message)
+                    }
 //                       // viewModel.process(HomeViewModel.Action.ClearMessage)
-//                    }
-//                }
+                }
                 if (state.updateApp) {
                     context.getActivity<MainActivity>()
                         ?.showUpdateDialog()

--- a/app/src/main/java/com/ih/osm/ui/pages/home/HomeScreenV2.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/home/HomeScreenV2.kt
@@ -123,7 +123,6 @@ fun HomeScreenV2(
                         viewModel.process(HomeAction.SyncCatalogs(LOAD_CATALOGS))
                     }
                     HomeActionClick.LOCAL_CARDS -> {
-                        Log.e("HomeScreenV2", "Intentando sincronizar tarjetas locales...")
                         viewModel.process(HomeAction.SyncLocalCards(context))
                     }
 
@@ -164,9 +163,7 @@ fun HomeScreenV2(
 //                } else if (state.isSyncing.not()) {
 //                  //  viewModel.process(HomeViewModel.Action.GetCards)
 //                }
-                Log.e("Snackbar", "Recibido mensaje en UI: ${state.message}")
                 if (state.message.isNotEmpty() && state.isLoading.not()) {
-                    Log.e("Snackbar", "Mostrando Snackbar con mensaje: ${state.message}")
                     scope.launch {
                         snackBarHostState.showSnackbar(message = state.message)
                     }

--- a/app/src/main/java/com/ih/osm/ui/pages/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/home/HomeViewModel.kt
@@ -65,7 +65,10 @@ class HomeViewModel
                 is HomeAction.GetCards -> handleGetCards()
                 is HomeAction.SyncCatalogs -> handleSyncCatalogs(action.syncCatalogs)
                 is HomeAction.SyncRemoteCards -> handleSyncRemoteCards()
-                is HomeAction.SyncLocalCards -> handleSyncLocalCards(action.context)
+                is HomeAction.SyncLocalCards -> {
+                    Log.e("HomeViewModel", "Recibida acción para sincronizar tarjetas locales")
+                    handleSyncLocalCards(action.context)
+                }
             }
         }
 
@@ -76,6 +79,7 @@ class HomeViewModel
         }
 
         private fun handleSyncLocalCards(appContext: Context) {
+            Log.e("HomeViewModel", "Entrando a handleSyncLocalCards()")
             viewModelScope.launch {
                 val state = getState()
                 if (NetworkConnection.isConnected().not() ||
@@ -83,6 +87,7 @@ class HomeViewModel
                     state.networkStatus == NetworkStatus.WIFI_DISCONNECTED ||
                     state.networkStatus == NetworkStatus.DATA_DISCONNECTED
                 ) {
+                    Log.e("HomeViewModel", "No hay conexión, mensaje: ${context.getString(R.string.please_connect_to_internet)}")
                     setState {
                         copy(
                             isLoading = false,
@@ -95,6 +100,12 @@ class HomeViewModel
                 if (state.networkStatus == NetworkStatus.DATA_CONNECTED &&
                     sharedPreferences.getNetworkPreference().isEmpty()
                 ) {
+                    Log.e(
+                        "HomeViewModel",
+                        "Datos móviles activos sin preferencia guardada, mensaje: : ${context.getString(
+                            R.string.network_preferences_allowed,
+                        )}",
+                    )
                     setState {
                         copy(
                             isLoading = false,
@@ -104,6 +115,7 @@ class HomeViewModel
                     }
                     return@launch
                 }
+                Log.e("HomeViewModel", "Enviando trajetas locales a sincronizar")
                 appContext.getActivity<MainActivity>()?.enqueueSyncCardsWork()
                 setState { copy(showSyncLocalCards = false) }
             }
@@ -214,6 +226,7 @@ class HomeViewModel
                     state.networkStatus == NetworkStatus.WIFI_DISCONNECTED ||
                     state.networkStatus == NetworkStatus.DATA_DISCONNECTED
                 ) {
+                    Log.e("HomeViewModel", "No hay conexión, mensaje a mostrar: ${context.getString(R.string.please_connect_to_internet)}")
                     setState {
                         copy(
                             isLoading = false,
@@ -305,13 +318,15 @@ class HomeViewModel
 
         //
         private fun cleanScreenStates(message: String = EMPTY) {
+            Log.e("HomeViewModel", "Limpiando estados, mensaje: $message")
             setState {
                 copy(
                     isLoading = false,
-                    message = message,
+                    message = if (message.isNotEmpty()) message else getState().message,
                     isSyncing = false,
                 )
             }
+            Log.e("HomeViewModel", "Después de limpiar estados, mensaje: ${getState().message}")
         }
 
         private fun checkPreferences() {

--- a/app/src/main/java/com/ih/osm/ui/pages/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/home/HomeViewModel.kt
@@ -66,7 +66,6 @@ class HomeViewModel
                 is HomeAction.SyncCatalogs -> handleSyncCatalogs(action.syncCatalogs)
                 is HomeAction.SyncRemoteCards -> handleSyncRemoteCards()
                 is HomeAction.SyncLocalCards -> {
-                    Log.e("HomeViewModel", "Recibida acción para sincronizar tarjetas locales")
                     handleSyncLocalCards(action.context)
                 }
             }
@@ -79,7 +78,6 @@ class HomeViewModel
         }
 
         private fun handleSyncLocalCards(appContext: Context) {
-            Log.e("HomeViewModel", "Entrando a handleSyncLocalCards()")
             viewModelScope.launch {
                 val state = getState()
                 if (NetworkConnection.isConnected().not() ||
@@ -87,7 +85,6 @@ class HomeViewModel
                     state.networkStatus == NetworkStatus.WIFI_DISCONNECTED ||
                     state.networkStatus == NetworkStatus.DATA_DISCONNECTED
                 ) {
-                    Log.e("HomeViewModel", "No hay conexión, mensaje: ${context.getString(R.string.please_connect_to_internet)}")
                     setState {
                         copy(
                             isLoading = false,
@@ -100,12 +97,6 @@ class HomeViewModel
                 if (state.networkStatus == NetworkStatus.DATA_CONNECTED &&
                     sharedPreferences.getNetworkPreference().isEmpty()
                 ) {
-                    Log.e(
-                        "HomeViewModel",
-                        "Datos móviles activos sin preferencia guardada, mensaje: : ${context.getString(
-                            R.string.network_preferences_allowed,
-                        )}",
-                    )
                     setState {
                         copy(
                             isLoading = false,
@@ -115,7 +106,6 @@ class HomeViewModel
                     }
                     return@launch
                 }
-                Log.e("HomeViewModel", "Enviando trajetas locales a sincronizar")
                 appContext.getActivity<MainActivity>()?.enqueueSyncCardsWork()
                 setState { copy(showSyncLocalCards = false) }
             }
@@ -226,7 +216,6 @@ class HomeViewModel
                     state.networkStatus == NetworkStatus.WIFI_DISCONNECTED ||
                     state.networkStatus == NetworkStatus.DATA_DISCONNECTED
                 ) {
-                    Log.e("HomeViewModel", "No hay conexión, mensaje a mostrar: ${context.getString(R.string.please_connect_to_internet)}")
                     setState {
                         copy(
                             isLoading = false,
@@ -318,7 +307,6 @@ class HomeViewModel
 
         //
         private fun cleanScreenStates(message: String = EMPTY) {
-            Log.e("HomeViewModel", "Limpiando estados, mensaje: $message")
             setState {
                 copy(
                     isLoading = false,
@@ -326,7 +314,6 @@ class HomeViewModel
                     isSyncing = false,
                 )
             }
-            Log.e("HomeViewModel", "Después de limpiar estados, mensaje: ${getState().message}")
         }
 
         private fun checkPreferences() {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,7 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="primary_app">#3e4e88</color>
+    <color name="button_green">#00FF00</color>
+    <color name="button_red">#FF0000</color>
+    <color name="button_gray">#808080</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="button_height">30dp</dimen>
+    <dimen name="button_padding_horizontal">8dp</dimen>
+    <dimen name="button_padding_vertical">4dp</dimen>
+    <dimen name="button_spacing">4dp</dimen>
+</resources>


### PR DESCRIPTION
### Feature / Bug Description
- A Snackbar was expected to appear in the UI when a specific event occurred, but it was not displaying properly.

### Solution
- Reviewed the LaunchedEffect implementation in HomeViewModel and HomeScreen.
- Added a scope.launch to ensure snackBarHostState.showSnackbar(state.message) executed correctly.
- Verified that state.message was being received correctly using logs.

### Notes
- n/a

### Screenshots / Screencasts
![Imagen de WhatsApp 2025-03-02 a las 00 50 01_f5e51749](https://github.com/user-attachments/assets/4d4ee493-b6be-468b-ae03-d631fe03afed)

### Feature / Bug Description
- The Switch used to enable/disable mobile data was unclear to users, so it needed to be replaced with a more intuitive control.

### Solution
- Replaced the Switch with two Segmented Buttons.
- Adjusted size and spacing to prevent UI misalignment.

### Notes
- n/a

### Screenshots / Screencasts
![Imagen de WhatsApp 2025-03-04 a las 19 40 54_b87cc541](https://github.com/user-attachments/assets/faf9c118-29d0-4281-aaa7-6b1ccba1f389)
![Imagen de WhatsApp 2025-03-04 a las 19 41 07_8ccec96e](https://github.com/user-attachments/assets/6459f57d-c97d-48d9-b201-515e03cf2b69)

### Feature / Bug Description
- In the card creation screen (CreateCardScreen), the priority field was displayed before the user had selected a problem type, which was not the expected behavior.

### Solution
- Modified CreateCardViewModel so that handleGetPriorities() only runs after selecting a preclassifier.
- Added a new function handleSetPreclassifier() that clears the selected priority before loading new priority options.
- Verified correct state updates using logs.

### Notes
- n/a

### Screenshots / Screencasts
![Imagen de WhatsApp 2025-03-04 a las 20 52 11_17df3c0e](https://github.com/user-attachments/assets/1cce18b1-5c36-4622-a335-dfe68c665dd8)

### Feature / Bug Description
- When uploading a client’s cards, it was noticed that the upload order was incorrect: the most recent cards were uploaded before the older ones, behaving like a stack (LIFO) instead of a queue (FIFO).

### Solution
- Reviewed CardRepositoryImpl and getAll(), where cards were being retrieved in the wrong order.
- Changed sortedByDescending { it.id } to sortedBy { it.id } to ensure FIFO order for the uploads.
- Added logs to verify the correct order after each synchronization.

### Notes
- n/a

### Screenshots / Screencasts
- n/a

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-67)