### PR TITLE
KAN-87 Implement logout api

### DIFF
--- a/app/src/main/java/com/ih/osm/data/api/ApiService.kt
+++ b/app/src/main/java/com/ih/osm/data/api/ApiService.kt
@@ -116,4 +116,9 @@ interface ApiService {
     fun updateMechanic(
         @Body body: UpdateMechanicRequest,
     ): Call<Any>
+
+    @POST("users/logout/{userId}")
+    suspend fun logout(
+        @Path("userId") userId: Int,
+    )
 }

--- a/app/src/main/java/com/ih/osm/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/ih/osm/data/repository/auth/AuthRepositoryImpl.kt
@@ -47,10 +47,9 @@ class AuthRepositoryImpl
         }
 
         override suspend fun logout(): Int {
-            dao.getUser()?.let {
-                return dao.deleteUser(it)
-            }
-            return 0
+            val user = dao.getUser() ?: return 0
+            networkRepository.logout(user.userId.toInt())
+            return dao.deleteUser(user)
         }
 
         override suspend fun getSiteId(): String {

--- a/app/src/main/java/com/ih/osm/data/repository/network/NetworkRepositoryImpl.kt
+++ b/app/src/main/java/com/ih/osm/data/repository/network/NetworkRepositoryImpl.kt
@@ -204,4 +204,20 @@ class NetworkRepositoryImpl
                 return e.localizedMessage.orEmpty()
             }
         }
+
+        override suspend fun logout(userId: Int) {
+            val response =
+                try {
+                    apiService.logout(userId)
+                    true
+                } catch (e: Exception) {
+                    FirebaseCrashlytics.getInstance().recordException(e)
+                    fileHelper.logException(e)
+                    throw e
+                }
+
+            if (!response) {
+                error("Error logging out of the server")
+            }
+        }
     }

--- a/app/src/main/java/com/ih/osm/domain/repository/network/NetworkRepository.kt
+++ b/app/src/main/java/com/ih/osm/domain/repository/network/NetworkRepository.kt
@@ -57,4 +57,6 @@ interface NetworkRepository {
     ): List<Card>
 
     suspend fun updateRemoteMechanic(body: UpdateMechanicRequest)
+
+    suspend fun logout(userId: Int)
 }

--- a/app/src/main/java/com/ih/osm/ui/pages/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/home/HomeViewModel.kt
@@ -310,7 +310,7 @@ class HomeViewModel
             setState {
                 copy(
                     isLoading = false,
-                    message = if (message.isNotEmpty()) message else getState().message,
+                    message = message,
                     isSyncing = false,
                 )
             }


### PR DESCRIPTION
### Feature / Bug Description
-  Implement logout service  in the app when the users taps on logout, call this method and then continue with the logout logic in the app.

### Solution
- Integrated the new logout API into the network layer.
- Implemented the service call in NetworkRepositoryImpl.
- Connected the API call in AuthRepositoryImpl.
- Kept the existing app logout flow in LogoutUseCaseImpl.

### Notes
- This ticket includes the message issue. The solution was assign message = message directly instead of keeping the previous one with getState().message when no new message is passed, so that calling cleanScreenStates() properly clears the "Loading data..." message. 

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-87)

### Screenshots / Screencasts