### PR TITLE
KAN-88 Update token api service

### DIFF
--- a/app/src/main/java/com/ih/osm/data/model/UpdateTokenRequest.kt
+++ b/app/src/main/java/com/ih/osm/data/model/UpdateTokenRequest.kt
@@ -3,4 +3,6 @@ package com.ih.osm.data.model
 data class UpdateTokenRequest(
     val userId: Int,
     val appToken: String,
+    val osName: String,
+    val osVersion: String,
 )

--- a/app/src/main/java/com/ih/osm/domain/usecase/user/UpdateTokenUseCase.kt
+++ b/app/src/main/java/com/ih/osm/domain/usecase/user/UpdateTokenUseCase.kt
@@ -1,5 +1,6 @@
 package com.ih.osm.domain.usecase.user
 
+import android.os.Build
 import com.ih.osm.data.model.UpdateTokenRequest
 import com.ih.osm.domain.repository.auth.AuthRepository
 import javax.inject.Inject
@@ -15,8 +16,10 @@ class UpdateTokenUseCaseImpl
     ) : UpdateTokenUseCase {
         override suspend fun invoke(token: String) {
             authRepository.get()?.let {
+                val osVersion = Build.VERSION.RELEASE ?: "unknown"
+                val osName = "Android ${Build.MODEL} ${Build.VERSION.SDK_INT}"
                 authRepository.updateToken(
-                    UpdateTokenRequest(userId = it.userId.toInt(), appToken = token),
+                    UpdateTokenRequest(userId = it.userId.toInt(), appToken = token, osName = osName, osVersion = osVersion),
                 )
             }
         }


### PR DESCRIPTION
### Feature / Bug Description
- Send the new parameters to update-token service, including the OS_NAME and OS_VERSION, get those values from the app, and send them to the api.

### Solution
- Modified UpdateTokenRequest to include the new fields.
- In UpdateTokenUseCaseImpl, added logic to retrieve and send osName and osVersion.
- Passed them into the UpdateTokenRequest.

### Notes
- n/a

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-88)

### Screenshots / Screencasts