### PR TITLE
KAN-83 Validate amount and duration evidence for cards

### DIFF
--- a/app/src/main/java/com/ih/osm/core/file/FileHelper.kt
+++ b/app/src/main/java/com/ih/osm/core/file/FileHelper.kt
@@ -1,6 +1,7 @@
 package com.ih.osm.core.file
 
 import android.content.Context
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import androidx.core.content.FileProvider
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -157,6 +158,19 @@ class FileHelper
                 }
             } catch (e: Exception) {
                 FirebaseCrashlytics.getInstance().recordException(e)
+            }
+        }
+
+        fun getDuration(uri: Uri): Long {
+            return try {
+                MediaMetadataRetriever().use { retriever ->
+                    retriever.setDataSource(context, uri)
+                    val durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                    durationStr?.toLongOrNull() ?: 0L
+                }
+            } catch (e: Exception) {
+                FirebaseCrashlytics.getInstance().recordException(e)
+                0L
             }
         }
     }

--- a/app/src/main/java/com/ih/osm/ui/pages/cardaction/CardActionViewModel.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/cardaction/CardActionViewModel.kt
@@ -114,19 +114,23 @@ class CardActionViewModel
 
                         EvidenceType.VICL, EvidenceType.VIPS -> {
                             val maxVideos = videoQuantity(actionType, cardType)
-                            if (state.evidences.toVideos().size == maxVideos) {
-                                context.getString(R.string.limit_videos)
-                            } else {
-                                EMPTY
+                            val maxVideoDuration = videoDuration(actionType, cardType) * 1000
+                            val duration = fileHelper.getDuration(uri)
+                            when {
+                                state.evidences.toVideos().size == maxVideos -> context.getString(R.string.limit_videos)
+                                duration > maxVideoDuration -> context.getString(R.string.limit_video_duration)
+                                else -> EMPTY
                             }
                         }
 
                         EvidenceType.AUCL, EvidenceType.AUPS -> {
                             val maxAudios = audiosQuantity(actionType, cardType)
-                            if (state.evidences.toAudios().size == maxAudios) {
-                                context.getString(R.string.limit_audios)
-                            } else {
-                                EMPTY
+                            val maxAudioDuration = audiosDuration(actionType, cardType)
+                            val duration = fileHelper.getDuration(uri)
+                            when {
+                                state.evidences.toAudios().size == maxAudios -> context.getString(R.string.limit_audios)
+                                duration > maxAudioDuration -> context.getString(R.string.limit_audio_duration)
+                                else -> EMPTY
                             }
                         }
 
@@ -178,6 +182,28 @@ class CardActionViewModel
             return when (actionType) {
                 is CardItemSheetAction.ProvisionalSolution -> cardType?.quantityAudiosPs
                 is CardItemSheetAction.DefinitiveSolution -> cardType?.quantityAudiosClose
+                else -> 0
+            }.defaultIfNull(0)
+        }
+
+        private fun audiosDuration(
+            actionType: CardItemSheetAction,
+            cardType: CardType?,
+        ): Int {
+            return when (actionType) {
+                is CardItemSheetAction.ProvisionalSolution -> cardType?.audiosDurationPs
+                is CardItemSheetAction.DefinitiveSolution -> cardType?.audiosDurationClose
+                else -> 0
+            }.defaultIfNull(0)
+        }
+
+        private fun videoDuration(
+            actionType: CardItemSheetAction,
+            cardType: CardType?,
+        ): Int {
+            return when (actionType) {
+                is CardItemSheetAction.ProvisionalSolution -> cardType?.videosDurationPs
+                is CardItemSheetAction.DefinitiveSolution -> cardType?.videosDurationClose
                 else -> 0
             }.defaultIfNull(0)
         }

--- a/app/src/main/java/com/ih/osm/ui/pages/createcard/CreateCardViewModel.kt
+++ b/app/src/main/java/com/ih/osm/ui/pages/createcard/CreateCardViewModel.kt
@@ -103,6 +103,7 @@ class CreateCardViewModel
             viewModelScope.launch {
                 val state = getState()
                 val cardType = state.cardType
+
                 val errorMessage =
                     when (type) {
                         EvidenceType.IMCR -> {
@@ -116,19 +117,31 @@ class CreateCardViewModel
 
                         EvidenceType.VICR -> {
                             val maxVideos = cardType?.quantityVideosCreate.defaultIfNull(0)
+                            val maxVideoDuration = cardType?.videosDurationCreate.defaultIfNull(0) * 1000
                             if (state.evidences.toVideos().size == maxVideos) {
                                 context.getString(R.string.limit_videos)
                             } else {
-                                EMPTY
+                                val videoDuration = fileHelper.getDuration(uri)
+                                if (videoDuration > maxVideoDuration) {
+                                    context.getString(R.string.limit_video_duration)
+                                } else {
+                                    EMPTY
+                                }
                             }
                         }
 
                         EvidenceType.AUCR -> {
                             val maxAudios = cardType?.quantityAudiosCreate.defaultIfNull(0)
+                            val maxAudioDuration = cardType?.audiosDurationCreate.defaultIfNull(0) * 1000
                             if (state.evidences.toAudios().size == maxAudios) {
                                 context.getString(R.string.limit_audios)
                             } else {
-                                EMPTY
+                                val audioduration = fileHelper.getDuration(uri)
+                                if (audioduration > maxAudioDuration) {
+                                    context.getString(R.string.limit_audio_duration)
+                                } else {
+                                    EMPTY
+                                }
                             }
                         }
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -76,6 +76,8 @@
     <string name="limit_images">Limite de imágenes permitidas</string>
     <string name="limit_videos">Limite de videos permitidos</string>
     <string name="limit_audios">Limite de audios permitidos</string>
+    <string name="limit_audio_duration">La duración del audio excede el límite permitido</string>
+    <string name="limit_video_duration">La duración del video excede el límite permitido</string>
     <string name="saving_card">Guardando tarjeta…</string>
     <string name="user">Usuario</string>
     <string name="search_for_a_user">Buscar usuario…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
     <string name="limit_images">Limit of images allowed for this card type</string>
     <string name="limit_videos">Limit of videos allowed for this card type</string>
     <string name="limit_audios">Limit of audios allowed for this card type</string>
+    <string name="limit_audio_duration">Audio exceeds the allowed duration</string>
+    <string name="limit_video_duration">Video exceeds the allowed duration</string>
     <string name="saving_card">Saving card…</string>
     <string name="user">User</string>
     <string name="search_for_a_user">Search for a user…</string>


### PR DESCRIPTION
### Feature / Bug Description
- Check the conditions and make sure that the card is validating the max amount of images, audios and videos, the duration of the audios and the duration for the videos for each card type, also for the provisional solution and definitive solution.

### Solution
- Quantity validation was already present in both ViewModels.
- Duration validation was added before allowing an evidence file to be added.
- The limits are retrieved from CardType:
audiosDurationPs or audiosDurationClose (depending if it is a Provisional or Definitive solution).
videosDurationPs or videosDurationClose.
- The real file duration (using MediaMetadataRetriever) is compared against these limits.
- An error message is shown if the file duration exceeds the allowed limit.

### Notes
- n/a

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-83)

### Screenshots / Screencasts
![Imagen de WhatsApp 2025-04-17 a las 14 33 46_e6e69ead](https://github.com/user-attachments/assets/0f96bb0f-bb1a-48c0-a01b-ab4fd2f7940b)
